### PR TITLE
Update semantic-version from v3.2.1 to v5.0.2

### DIFF
--- a/.github/workflows/auto-git-release.yml
+++ b/.github/workflows/auto-git-release.yml
@@ -18,14 +18,14 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # See https://github.com/PaulHatch/semantic-version#important-note-regarding-the-checkout-action
-      - uses: paulhatch/semantic-version@v3.2.1
+      - uses: paulhatch/semantic-version@v5.0.2
         id: next_semantic_version # Output: https://github.com/PaulHatch/semantic-version/blob/master/index.js#L63-L69
         with: # See https://github.com/PaulHatch/semantic-version#usage
           branch: main # Force "main" instead of "master" by default
           tag_prefix: "v" # The prefix to use to identify tags
           major_pattern: "(MAJOR)" # A string which, if present in a git commit, indicates that a change represents a major (breaking) change
           minor_pattern: "(MINOR)" # Same as above except indicating a minor change
-          format: "${major}.${minor}.${patch}-prerelease.${increment}" # A string to determine the format of the version output
+          version_format: "${major}.${minor}.${patch}-prerelease.${increment}" # A string to determine the format of the version output
           short_tags: false # If set to false, short tags like "v1" will not be considered, only full versions tags such as "v1.0.0" will be used to determine the version. XXX This is necessary because of our "auto-tag-on-release" which updates "latest" and causes conflicts
           bump_each_commit: true # If this input is set to true, every commit will be treated as a new version, bumping the patch, minor, or major version based on the commit message.
       - run: |


### PR DESCRIPTION
Closes https://github.com/UnlyEd/github-action-await-vercel/issues/82