### PR TITLE
chore(devexp): use node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,5 +19,5 @@ outputs:
   deploymentDetails:
     description: 'Forwarded Vercel API response - See https://vercel.com/docs/api#endpoints/deployments/get-a-single-deployment/response-parameters'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'github-action-runtime/index.js'


### PR DESCRIPTION
Fix warning 
- closes: #104 
```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: UnlyEd/github-action-await-vercel@v1.2.43.
```

<img width="1136" alt="image" src="https://github.com/UnlyEd/github-action-await-vercel/assets/95273550/96f230ed-5fc6-4ae0-bc6a-67c207e389f7">
